### PR TITLE
Updating model for Refund Fail webhook and small improvements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @amihajlovski @dcardos @shanikantsingh @shubhamvijaivargiya @zenit2001
+* @amihajlovski @dcardos @shanikantsingh @shubhamk67 @shubhamvijaivargiya @zenit2001

--- a/force-app/main/default/classes/AdyenConstants.cls
+++ b/force-app/main/default/classes/AdyenConstants.cls
@@ -5,28 +5,31 @@ public with sharing class AdyenConstants {
     public static final String DEFAULT_ADAPTER_NAME = 'AdyenDefault';
 
     @NamespaceAccessible
-    public static final String NOTIFICATION_REQUEST_TYPE_CANCEL = 'cancellation';
+    public static final String NOTIFICATION_REQUEST_TYPE_CANCEL = 'CANCELLATION';
 
     @NamespaceAccessible
-    public static final String NOTIFICATION_REQUEST_TYPE_AUTHORISE = 'authorization';
+    public static final String NOTIFICATION_REQUEST_TYPE_AUTHORISE = 'AUTHORISATION';
 
     @NamespaceAccessible
-    public static final String NOTIFICATION_REQUEST_TYPE_CAPTURE_FAILED = 'capture-failed';
+    public static final String NOTIFICATION_REQUEST_TYPE_CAPTURE_FAILED = 'CAPTURE_FAILED';
 
     @NamespaceAccessible
-    public static final String NOTIFICATION_REQUEST_TYPE_CAPTURE  = 'capture';
+    public static final String NOTIFICATION_REQUEST_TYPE_REFUND_FAILED = 'REFUND_FAILED';
 
     @NamespaceAccessible
-    public static final String NOTIFICATION_REQUEST_TYPE_REFUND   = 'refund';
+    public static final String NOTIFICATION_REQUEST_TYPE_CAPTURE = 'CAPTURE';
 
     @NamespaceAccessible
-    public static final String NOTIFICATION_REQUEST_TYPE_RECURRING_CONTRACT   = 'recurring_contract';
+    public static final String NOTIFICATION_REQUEST_TYPE_REFUND = 'REFUND';
 
     @NamespaceAccessible
-    public static final String NOTIFICATION_ACCEPTED_RESPONSE     = '[accepted]';
+    public static final String NOTIFICATION_REQUEST_TYPE_RECURRING_CONTRACT = 'RECURRING_CONTRACT';
 
     @NamespaceAccessible
-    public static final String NOTIFICATION_RECEIVED_CHECKOUT  = 'received';
+    public static final String NOTIFICATION_ACCEPTED_RESPONSE = '[accepted]';
+
+    @NamespaceAccessible
+    public static final String NOTIFICATION_RECEIVED_CHECKOUT = 'received';
 
     @NamespaceAccessible
     public static final String TEST_MERCHANT_ACCOUNT = 'TEST_MERCHANT_ACCOUNT';
@@ -66,5 +69,5 @@ public with sharing class AdyenConstants {
     public static final Integer HTTP_ERROR_CODE = 400;
 
     @NamespaceAccessible
-    public  final static String HTTP_SERVER_ERROR_CODE = '500';
+    public static final Integer HTTP_SERVER_ERROR_CODE = 500;
 }

--- a/force-app/main/default/classes/AdyenConstants.cls-meta.xml
+++ b/force-app/main/default/classes/AdyenConstants.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>59.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HMACValidator.cls
+++ b/force-app/main/default/classes/HMACValidator.cls
@@ -1,13 +1,28 @@
-@namespaceAccessible
+@NamespaceAccessible
 public with sharing class HMACValidator {
     private static final String HMAC_SHA256_ALGORITHM = 'HmacSHA256';
     private static final String DATA_SEPARATOR = ':';
-    
-    @namespaceAccessible
+    private final NotificationRequestItem notificationRequestItem;
+    private final String hmacKey;
+
+    public HMACValidator(NotificationRequestItem notificationRequestItem, String hmacKey) {
+        if (notificationRequestItem == null) {
+            throw new HmacValidationException('Invalid notification request item');
+        }
+
+        if (String.isBlank(hmacKey)) {
+            throw new HmacValidationException('Invalid HMAC Key');
+        }
+
+        this.notificationRequestItem = notificationRequestItem;
+        this.hmacKey = hmacKey;
+    }
+
+    @NamespaceAccessible
     public class HmacValidationException extends Exception {}
 
     @TestVisible
-    private String calculateHMAC(NotificationRequestItem notificationRequestItem, String key){
+    private String calculateHMAC() {
         List<Object> payloadParts = new List<Object>{
             notificationRequestItem.pspReference,
             notificationRequestItem.originalReference,
@@ -18,11 +33,11 @@ public with sharing class HMACValidator {
             notificationRequestItem.eventCode,
             notificationRequestItem.success
         };
-        
+
         String payload = String.join(payloadParts, DATA_SEPARATOR);
         Blob binaryPayload = Blob.valueOf(payload); // Convert payload to binary
 
-        Blob binaryKey = EncodingUtil.convertFromHex(key); // Convert hexadecimal string to binary
+        Blob binaryKey = EncodingUtil.convertFromHex(hmacKey); // Convert hexadecimal string to binary
 
         Blob hmac = Crypto.generateMac(HMAC_SHA256_ALGORITHM, binaryPayload, binaryKey);
         String hmacBase64 = EncodingUtil.base64Encode(hmac);
@@ -31,27 +46,27 @@ public with sharing class HMACValidator {
 
     // Prevents timing attacks
     @TestVisible
-    private Boolean compareHMAC(String hmacSignature, String merchantSignature) {
-        if (hmacSignature.length() != merchantSignature.length()) {
+    private static Boolean compareHMAC(String calculatedSignature, String merchantSignature) {
+        if (calculatedSignature.length() != merchantSignature.length()) {
             return false;
         }
-        
+
         Integer bitwiseComparison = 0;
-        for (Integer i = 0; i < hmacSignature.length(); i++) {
-            bitwiseComparison |= hmacSignature.charAt(i) ^ merchantSignature.charAt(i);
+        for (Integer i = 0; i < calculatedSignature.length(); i++) {
+            bitwiseComparison |= calculatedSignature.charAt(i) ^ merchantSignature.charAt(i);
         }
-        
+
         return bitwiseComparison == 0;
     }
-    
-   @namespaceAccessible
-   public Boolean validateHMAC(NotificationRequestItem notificationRequestItem, String hmacKey){
-        String hmacSignature = notificationRequestItem.additionalData?.get('hmacSignature');
-        if (String.isBlank(hmacSignature)) {
+
+    @NamespaceAccessible
+    public Boolean validateHMAC() {
+        String merchantSignature = notificationRequestItem.additionalData?.get('hmacSignature');
+        if (String.isBlank(merchantSignature)) {
             throw new HmacValidationException('Missing notification data');
         }
-        String calculatedSignature = calculateHMAC(notificationRequestItem, hmacKey);
+        String calculatedSignature = calculateHMAC();
 
-        return compareHMAC(calculatedSignature, hmacSignature);
+        return compareHMAC(calculatedSignature, merchantSignature);
     }
 }

--- a/force-app/main/default/classes/HMACValidator.cls-meta.xml
+++ b/force-app/main/default/classes/HMACValidator.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>59.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/HMACValidatorTest.cls
+++ b/force-app/main/default/classes/HMACValidatorTest.cls
@@ -1,7 +1,7 @@
-@isTest
+@IsTest
 private class HMACValidatorTest {
 
-    @isTest
+    @IsTest
     static void testCalculateHMAC() {
         NotificationRequestItem requestItem = new NotificationRequestItem();
         requestItem.amount = new Amount();
@@ -17,14 +17,14 @@ private class HMACValidatorTest {
 
         String hmacKey = '0123456789ABCDEF';
 
-        HMACValidator validator = new HMACValidator();
-        String hmac = validator.calculateHMAC(requestItem, hmacKey);
+        HMACValidator validator = new HMACValidator(requestItem, hmacKey);
+        String hmac = validator.calculateHMAC();
 
         // Assert that the HMAC is not null
         Assert.isNotNull(hmac);
     }
 
-    @isTest
+    @IsTest
     static void testValidateHMAC() {
         NotificationRequestItem requestItem = new NotificationRequestItem();
         requestItem.amount = new Amount();
@@ -39,19 +39,19 @@ private class HMACValidatorTest {
 
         String hmacKey = '0123456789ABCDEF';
 
-        HMACValidator validator = new HMACValidator();
-        String expectedHmac = validator.calculateHMAC(requestItem, hmacKey);
+        HMACValidator validator = new HMACValidator(requestItem, hmacKey);
+        String expectedHmac = validator.calculateHMAC();
 
         requestItem.additionalData = new Map<String, String>{
             'hmacSignature' => expectedHmac
         };
 
-        Boolean isValid = validator.validateHMAC(requestItem, hmacKey);
+        Boolean isValid = validator.validateHMAC();
 
         Assert.isTrue(isValid);
     }
 
-    @isTest
+    @IsTest
     static void testInvalidHMAC() {
         NotificationRequestItem requestItem = new NotificationRequestItem();
 
@@ -73,14 +73,14 @@ private class HMACValidatorTest {
             'hmacSignature' => 'coqCmt/IZ4E3CzPvMY8zTjQVL5hYJUiBRg8UU+iCWo0'
         };
 
-        HMACValidator validator = new HMACValidator();
-        Boolean isValid = validator.validateHMAC(requestItem, hmacKey);
+        HMACValidator validator = new HMACValidator(requestItem, hmacKey);
+        Boolean isValid = validator.validateHMAC();
 
         Assert.isFalse(isValid);
     }
 
     // Tests the correct HMAC creation
-    @isTest
+    @IsTest
     static void testCorrectHMACSignatureCreation() {
         NotificationRequestItem requestItem = new NotificationRequestItem();
         requestItem.amount = new Amount();
@@ -95,22 +95,37 @@ private class HMACValidatorTest {
 
         String hmacKey = '44782DEF547AAA06C910C43932B1EB0C71FC68D9D0C057550C48EC2ACF6BA056';
 
-        HMACValidator validator = new HMACValidator();
-        String expectedHmac = validator.calculateHMAC(requestItem, hmacKey);
+        HMACValidator validator = new HMACValidator(requestItem, hmacKey);
+        String expectedHmac = validator.calculateHMAC();
         Assert.areEqual('coqCmt/IZ4E3CzPvMY8zTjQVL5hYJUiBRg8UU+iCWo0=', expectedHmac);
     }
 
-    @isTest
+    @IsTest
     static void testHMACException() {
-        try{
-            NotificationRequestItem requestItem = new NotificationRequestItem();
-            String hmacKey = null;
-            HMACValidator validator = new HMACValidator();
-            Boolean isValid = validator.validateHMAC(requestItem, hmacKey);
+        NotificationRequestItem requestItem = new NotificationRequestItem();
+        String hmacKey = 'some key';
+        HMACValidator validator;
+        // given no Notification Request Item
+        try { // when
+            validator = new HMACValidator(null, hmacKey);
             Assert.fail();
+        } catch(HMACValidator.HmacValidationException ex) { // then
+            Assert.isTrue(ex.getMessage().containsIgnoreCase('Invalid'));
         }
-        catch(HMACValidator.HmacValidationException e){
-            Assert.areEqual('Missing notification data', e.getMessage());
+        // given no hmac key
+        try { // when
+            validator = new HMACValidator(requestItem, null);
+            Assert.fail();
+        } catch(HMACValidator.HmacValidationException ex) { // then
+            Assert.isTrue(ex.getMessage().containsIgnoreCase('Invalid'));
+        }
+        // given no merchant signature
+        try { // when
+            validator = new HMACValidator(requestItem, hmacKey);
+            validator.validateHMAC();
+            Assert.fail();
+        } catch(HMACValidator.HmacValidationException ex) { // then
+            Assert.isTrue(ex.getMessage().containsIgnoreCase('Missing'));
         }
     }
 }

--- a/force-app/main/default/classes/HMACValidatorTest.cls-meta.xml
+++ b/force-app/main/default/classes/HMACValidatorTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>59.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/force-app/main/default/classes/NotificationRequestItem.cls
+++ b/force-app/main/default/classes/NotificationRequestItem.cls
@@ -28,9 +28,6 @@ public with sharing class NotificationRequestItem {
     public String originalReference {get;set;}
 
     @NamespaceAccessible
-    public String paymentPspReference {get;set;}
-
-    @NamespaceAccessible
     public String pspReference {get;set;}
 
     @NamespaceAccessible

--- a/force-app/main/default/classes/NotificationRequestItem.cls-meta.xml
+++ b/force-app/main/default/classes/NotificationRequestItem.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>59.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
So next release of OMS can log refund_fail webhook, given merchant visibility of when this happens in SF.

Additionally
 - removing deprecated and unused `paymentPspReference` variable from `NotificationRequestItem`
 - converting string to integer for http server error code
 - small refactoring of HMAC class to fix lint issues