### PR TITLE
Fix: undeleting classes to avoid OMS upgrade blockage

### DIFF
--- a/force-app/main/default/classes/AdyenClient.cls
+++ b/force-app/main/default/classes/AdyenClient.cls
@@ -1,0 +1,44 @@
+/*
+* Adyen Checkout API
+* Adyen Checkout API provides a simple and flexible way to initiate and authorise online payments.
+* You can use the same integration for payments made with cards (including 3D Secure), mobile wallets, and local payment methods (for example, iDEAL and Sofort).
+* This API reference provides information on available endpoints and how to interact with them. To learn more about the API, visit [Checkout documentation](https://docs.adyen.com/checkout).\n\n## Authentication\nEach request to the Checkout API must be signed with an API key. For this, obtain an API Key from your Customer Area, as described in [How to get the API key](https://docs.adyen.com/user-management/how-to-get-the-api-key). Then set this key to the `X-API-Key` header value, for example:\n\n```\ncurl\n-H "Content-Type: application/json" \\n-H "X-API-Key: Your_Checkout_API_key" \\n...\n```\nNote that when going live, you need to generate a new API Key to access the [live endpoints](https://docs.adyen.com/development-resources/live-endpoints).\n\n## Versioning\nCheckout API supports versioning of its endpoints through a version suffix in the endpoint URL. This suffix has the following format: "vXX", where XX is the version number.\n\nFor example:\n```\nhttps://checkout-test.adyen.com/v64/payments\n```
+*
+* Contact: support@adyen.com
+*
+*/
+
+@NamespaceAccessible
+public with sharing class AdyenClient {
+
+    @NamespaceAccessible
+    public AdyenConfig config;
+
+    @NamespaceAccessible
+    public AdyenClient(String apiKey, String endpoint) {
+        this.config = new AdyenConfig();
+        this.config.setApiKey(apiKey);
+        this.config.setEndpoint(endpoint);
+    }
+
+    @NamespaceAccessible
+    public HttpResponse request(AdyenConfig config, String request) {
+        HttpRequest httpRequest = createHttpRequest(config, request);
+        return sendRequest(httpRequest);
+    }
+
+    private static HttpResponse sendRequest(HttpRequest request) {
+        CommercePayments.PaymentsHttp httpClient = new CommercePayments.PaymentsHttp();
+        return httpClient.send(request);
+    }
+
+    private static HttpRequest createHttpRequest(AdyenConfig config, String request) {
+        HttpRequest httpReq = new HttpRequest();
+        httpReq.setEndpoint(config.getEndpoint());
+        httpReq.setMethod('POST');
+        httpReq.setHeader('X-API-KEY', config.getApiKey());
+        httpReq.setHeader('Content-Type', 'application/json');
+        httpReq.setBody(request);
+        return httpReq;
+    }
+}

--- a/force-app/main/default/classes/AdyenClient.cls-meta.xml
+++ b/force-app/main/default/classes/AdyenClient.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/AdyenClientTest.cls
+++ b/force-app/main/default/classes/AdyenClientTest.cls
@@ -1,0 +1,17 @@
+@IsTest
+public class AdyenClientTest {
+
+    /**
+    * Test method to enhance code coverage for Apex Models; This ain't validating any specific business use case.
+    * Enhances code coverage for AdyenClient apex class
+    */
+    @IsTest
+    private static void testAllMethodsFromAdyenClient() {
+        Test.setMock(HttpCalloutMock.class, new ApiLibMock.AdyenPaymentsSuccessMock());
+        AdyenClient testADNC = new AdyenClient('37ufgu3iyrfhed','https://testendpoint.com');
+        Test.startTest();
+        HttpResponse res = testADNC.request(testADNC.config,'testrequeststring');
+        Test.stopTest();
+        System.assert(res!=null,'This is from AdyenClientTest');
+    }
+}

--- a/force-app/main/default/classes/AdyenClientTest.cls-meta.xml
+++ b/force-app/main/default/classes/AdyenClientTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/NotificationRequestItem.cls
+++ b/force-app/main/default/classes/NotificationRequestItem.cls
@@ -28,6 +28,9 @@ public with sharing class NotificationRequestItem {
     public String originalReference {get;set;}
 
     @NamespaceAccessible
+    public String paymentPspReference {get;set;}
+
+    @NamespaceAccessible
     public String pspReference {get;set;}
 
     @NamespaceAccessible


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Describe the changes proposed in this pull request:
- What is the motivation for this change?
Making sure OMS does not get missing dependency when trying to upgrade the package because of deleted class or attribute in Apex Lib.